### PR TITLE
Modifications to compile

### DIFF
--- a/src/InputOutput.f90
+++ b/src/InputOutput.f90
@@ -700,8 +700,8 @@ module InputOutput
 			singleRun = (params%params%StartCoreChar .eq. "0")
 			! Should probably have an input option to always output per core even when a single run - hence two lines here - but not
 			! currently implemented
-			params%outputParams%outputPerCore = .not. singleRun
-			params%outputParams%outputCombined = singleRun
+			params%outputParams%outputPerCore = .true.
+			params%outputParams%outputCombined = .true.
 
 			! No purpose is served in writing out swappable info if data is prephased
 			params%outputParams%outputSwappable = params%outputParams%outputSwappable .and. (.not. (params%GenotypeFileFormat /= 2))

--- a/src/MemberManagerModule.f90
+++ b/src/MemberManagerModule.f90
@@ -132,14 +132,16 @@ contains
         class(MemberManager) :: manager
         class(CoreType), intent(in), target :: c
         integer, intent(in) :: number
+		integer :: nAnisG
+        logical, allocatable :: used(:)
 
-        logical, dimension(c%getNAnisG()) :: used
-        integer :: nAnisG, numUsed, curMax, curOrder, seed, i, curIndiv, curSize
+        integer :: numUsed, curMax, curOrder, seed, i, curIndiv, curSize
         type(Genotype), pointer :: g1, g2
 
         manager%c => c
 
-        nAnisG = c%getNAnisG()
+		nAnisG = c%getNAnisG()
+        allocate(used(nAnisG))
         allocate(manager%order(nAnisG))
         used = .false.
         numUsed = 0


### PR DESCRIPTION
This pull request includes the changes I made to successfully compile the repository using Intel's ifx compiler with MKL support. 

**Compilation**
The default `Compile.sh` script didn't work in my environment because `ifor` compiler is not availble, so I compiled the project using the following steps:

> rm -rf build
> mkdir build
> cd build
> cmake .. -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_Fortran_FLAGS="-qmkl"
> make


**Cloning**
When cloning with `git clone --recurse-submodules https://github.com/AlphaGenes/AlphaPhase.git` the three submodules, `alphacmakefiles`, `alphaphase-doc`, and `alphahouse`, are retrieved from BitBucket, which caused access issues on my end. I manually downloaded them from their respective GitHub repositories instead:

> git clone https://github.com/AlphaGenes/AlphaCMakeFiles.git
> cp -r ./AlphaCMakeFiles/* alphacmakefiles/
> rm -r AlphaCMakeFiles
> 
> git clone https://github.com/AlphaGenes/AlphaHouse.git
> cp -r ./AlphaHouse/* alphahouse/
> rm -r AlphaHouse
> 
> git clone https://github.com/AlphaGenes/AlphaPhase-doc.git
> cp -r ./AlphaPhase-doc/* alphaphase-doc/
> rm -r AlphaPhase-doc

**Changes**
Most changes were made to the linked repository and were necessary to address compilation errors or warnings. Below is a summary of the changes:

1. `AlphaPhase/alphahouse/src/Utilities/LinkedListModule.f90`
Line 186: Removed pure statement (was causing compilation issues).

2. `AlphaPhase/alphahouse/src/Utilities/HashModule.f90`
Line 222: Removed pure statement.

3. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1054: Added a new paragraph after &.

4. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1060: Added a new paragraph after &.

5. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1067: Added a new paragraph after &.

6. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1068: Added a new paragraph after &.

7. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1080: Added a new paragraph after &.

8. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1085: Added a new paragraph after &.

9. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1091: Added a new paragraph after &.

10. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1101: Added a new paragraph after &.

11. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1106: Added a new paragraph after &.

12. `AlphaPhase/alphahouse/src/BioComputational/PedigreeModule.f90`
Line 1112: Added a new paragraph after &.

These changes were made to fix syntax/formatting errors with line continuation in Fortran.

13. `AlphaPhase/alphahouse/src/Utilities/CompatibilityModule.f90`
Line 1213: Defined a temporary variable tmpBimInfo to temporarily store data returned from the createBimInfoFromGenotypes function.

14. `AlphaPhase/alphahouse/src/Utilities/LineModule.f90`
Line 249: Removed pure statement.

15. `AlphaPhase/alphahouse/src/Utilities/LineModule.f90`
Line 275: Removed pure statement.

16. `AlphaPhase/src/MemberManagerModule.f90`
Line 136: Removed type-bound function call to getNAnisG() since it's not declared pure and thus not suitable in this context.

**Output and Debugging Enhancement**
17.  `AlphaPhase/src/InputOutput.f90`
Lines 703-704: Modified to print all output results explicitly

**New options and parameters**
I could observed some new functions were explored (I'm not sure if they were completelly implemented) and the documentation has not yet been updated to reflect these recent changes in this software. In particular, new options such as printing results by cores instead of by genotype are currently not explained in the user guide or help documentation. 

**Feel free to invite me to collaborate (to the best of my knowledge) to continue contributing to the development and maintenance of these repositories and their respective documentation. I haven't wanted to make many changes in this pull request, as I know these are interconnected and highly developed packages, thus avoiding incompatibility issues, etc. I'd be happy to continue supporting you in any way necessary.**